### PR TITLE
Fix references to jeison in the copyright/license text

### DIFF
--- a/clang-format+.el
+++ b/clang-format+.el
@@ -10,19 +10,18 @@
 
 ;; This file is NOT part of GNU Emacs.
 
-;; jeison is free software: you can redistribute it and/or modify
+;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or
 ;; (at your option) any later version.
 
-;; jeison is distributed in the hope that it will be useful,
+;; This program is distributed in the hope that it will be useful,
 ;; but WITHOUT ANY WARRANTY; without even the implied warranty of
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ;; GNU General Public License for more details.
 
 ;; You should have received a copy of the GNU General Public License
-;; along with jeison.
-;; If not, see <https://www.gnu.org/licenses/>.
+;; along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 


### PR DESCRIPTION
It seem like the copyright/license text was copied from some other project? I suggest replacing jeison with "this program" instead of "clang-format+" since that's how the text usually is written AFAIK.