### PR TITLE
Only enable formatting if a style has been selected

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,17 +45,18 @@ After that you should clone this repo and add the following code to you `init.el
 
 ### Setting up a hook
 
-You can use *clang-format+* for every C/C++ projects you edit:
+You can use *clang-format+* for all C/C++ projects you edit:
 
 ``` emacs-lisp
 (add-hook 'c-mode-common-hook #'clang-format+-mode)
 ```
 
+This will enable automatic formatting of C/C++ files in source trees with a [`.clang-format`](https://clang.llvm.org/docs/ClangFormatStyleOptions.html) (or `_clang-format`) file, or *all* C/C++ files if the variable `clang-format-style` is set to something else than "file". You can set `clang-format+-always-enable` to `t` to force formatting; then the default LLVM style will be used if not specified otherwise.
+
+
 ### Project-level hook
 
-Not all projects use **clang-format** so it might be not reasonable to set `clang-format+-mode` for every project, especially if you need to switch between them.
-
-For this reason, it might be better starting *clang-format+* only for files in certain projects. You can add [.dir-locals.el](https://www.gnu.org/software/emacs/manual/html_node/emacs/Directory-Variables.html) file in the root directory of your project with the following code inside:
+If you don't want to enable formatting for all projects with a `.clang-format`/`_clang-format` file, you can do it selectively by adding a [.dir-locals.el](https://www.gnu.org/software/emacs/manual/html_node/emacs/Directory-Variables.html) file in the root directory of your project with the following code inside:
 
 ``` emacs-lisp
 ((c++-mode . ((mode . clang-format+))))
@@ -63,11 +64,12 @@ For this reason, it might be better starting *clang-format+* only for files in c
 
 ## Customization
 
-*clang-format+* defines three variables the user can tweak:
+*clang-format+* defines these variables that the user can tweak:
 
 - `clang-format+-apply-to-modifications-only` defines whether **clang-format** should be applied to the whole buffer or only to the modified parts of it (`t` by default)
 - `clang-format+-apply-to-modified-definition` defines whether **clang-format** should format all definitions (functions/classes/etc.) containing modifications (`t` by default). *clang-format+* enlarges modified areas to their enclosing definitions so the formatting looks more consistent.
 - `clang-format+-offset-modified-region` defines a number of extra lines added *before* and *after* modified regions to be formatted (`0` by default). If `clang-format+-apply-to-modified-definition` is `t` it will be applied only when outside of definitions.
+- `clang-format+-always-enable` defines whether to enable formatting even if a style hasn't been selected. If `clang-format+-always-enable` is `nil` (which is the default), formatting will be enabled if there is a `.clang-format`/`_clang-format` file in the source tree or if `clang-format-style` is set to something else than "file". If non-`nil`, formatting will always be enabled.
 
 ## Contribute
 

--- a/test/clang-format+-test.el
+++ b/test/clang-format+-test.el
@@ -2,6 +2,8 @@
 
 (require 'clang-format+)
 
+(setq clang-format+-always-enable t)
+
 (ert-deftest clang-format+:basic-test ()
   (with-temp-buffer
     (c++-mode)


### PR DESCRIPTION
Added a new option “clang-format+-always-enable” which defaults to nil. If clang-format+-always-enable is nil, then only enable formatting if there is a .clang-format (or _clang-format) file in the source tree, or if clang-format-style is not set to “file”. This makes clang-format+ do what I believe most people would expect it to do by default.

The mode line indicator will be “cf+” is formatting is enabled, otherwise “cf-”. Does this seem like a good idea? Other options could be “!cf+" or “" if formatting is not enabled.

Closes #2.