### PR TITLE
Introduce clang-format+-context setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,11 @@ If you don't want to enable formatting for all projects with a `.clang-format`/`
 
 *clang-format+* defines these variables that the user can tweak:
 
-- `clang-format+-apply-to-modifications-only` defines whether **clang-format** should be applied to the whole buffer or only to the modified parts of it (`t` by default)
-- `clang-format+-apply-to-modified-definition` defines whether **clang-format** should format all definitions (functions/classes/etc.) containing modifications (`t` by default). *clang-format+* enlarges modified areas to their enclosing definitions so the formatting looks more consistent.
-- `clang-format+-offset-modified-region` defines a number of extra lines added *before* and *after* modified regions to be formatted (`0` by default). If `clang-format+-apply-to-modified-definition` is `t` it will be applied only when outside of definitions.
+- `clang-format+-context` defines how much context to reformat after modifications. Possible values:
+    * `'buffer`: Reformat the whole buffer.
+    * `'definition`: Reformat the enclosing definition (class/function/etc., but not namespace). This is the default.
+    * `'modification`: Reformat only the modified parts.
+- `clang-format+-offset-modified-region` defines the number of extra lines to reformat outside of a modified region both *before* and *after* (`0` by default). If `clang-format+-context` is `'definition'`, the region will only be extended for modifications outside of definitions.
 - `clang-format+-always-enable` defines whether to enable formatting even if a style hasn't been selected. If `clang-format+-always-enable` is `nil` (which is the default), formatting will be enabled if there is a `.clang-format`/`_clang-format` file in the source tree or if `clang-format-style` is set to something else than "file". If non-`nil`, formatting will always be enabled.
 
 ## Contribute

--- a/clang-format+.el
+++ b/clang-format+.el
@@ -39,27 +39,34 @@
   "Minor mode for automatic clang-format application"
   :group 'convenience)
 
-(defcustom clang-format+-apply-to-modifications-only
-  t
-  "Format only modified parts of the buffer or the whole buffer."
-  :type 'boolean
-  :group 'clang-format+)
+(defcustom clang-format+-context
+  'definition
+  "How much context to reformat after modifications.
 
-(defcustom clang-format+-apply-to-modified-definition
-  t
-  "Format the whole class or function that has been modified.
+When a buffer is modified, clang-format+ can reformat only the
+modified parts or larger enclosing contexts. The default is to
+reformat the whole class or function in which a modification is
+made.
 
-Makes a difference only when `clang-format+-apply-to-modifications-only' is t."
-  :type 'boolean
+Possible values:
+
+`buffer'        Reformat the whole buffer.
+`definition'    Reformat the enclosing definition (class/function/etc., but not
+                namespace).
+`modification'  Reformat only the modified parts."
+  :type '(choice (const :tag "The whole buffer" buffer)
+                 (const :tag "The whole class or function" definition)
+                 (const :tag "Only the modification" modification))
   :group 'clang-format+)
 
 (defcustom clang-format+-offset-modified-region
   0
-  "Number of lines to add to the modified region.
+  "Number of extra lines to reformat outside of a modified region.
 
-Clang-format+ adds it both to the beginning and to the end of the region.
-Used only when `clang-format+-apply-to-modified-definition' is nil or
-when not inside of the function."
+Clang-format+ extends the region to reformat both at the
+beginning and at the end. If `clang-format+-context' is set to
+`definition', the region will only be extended for modifications
+outside of definitions."
   :type 'integer
   :group 'clang-format+)
 
@@ -109,9 +116,9 @@ in place."
 
 (defun clang-format+-before-save ()
   "Run ‘clang-format’ on the current buffer."
-  (if clang-format+-apply-to-modifications-only
-      (clang-format+-apply-to-modifications)
-    (clang-format-buffer)))
+  (if (eq clang-format+-context 'buffer)
+      (clang-format-buffer)
+    (clang-format+-apply-to-modifications)))
 
 (defun clang-format+-apply-to-modifications ()
   "Apply ‘clang-format’ to modified parts of the current buffer."
@@ -175,7 +182,7 @@ FALLBACK-MOVE will be used if POINTER is outside of the definition,
 or when modification of the whole definition is not allowed."
   (save-excursion
     (goto-char pointer)
-    (if (and clang-format+-apply-to-modified-definition
+    (if (and (eq clang-format+-context 'definition)
              (clang-format+-inside-of-enclosing-definition-p))
         (funcall definition-move)
       (funcall fallback-move clang-format+-offset-modified-region))

--- a/test/clang-format+-test.el
+++ b/test/clang-format+-test.el
@@ -26,7 +26,7 @@
                    "\nclass A    {\n\n  int foo(){\n\n  };\n};\n"))))
 
 (ert-deftest clang-format+:apply-to-all-test ()
-  (let ((clang-format+-apply-to-modifications-only nil)
+  (let ((clang-format+-context 'buffer)
         (clang-format-style "llvm"))
     (with-temp-buffer
       (switch-to-buffer (current-buffer))
@@ -40,7 +40,7 @@
                      "\nclass A {\npublic:\n  int foo(){\n\n  };\n};\n")))))
 
 (ert-deftest clang-format+:no-definition-test ()
-  (let ((clang-format+-apply-to-modified-definition nil))
+  (let ((clang-format+-context 'modification))
     (with-temp-buffer
       (switch-to-buffer (current-buffer))
       (insert "\nclass A    {\n\npublic:\n\n};\n")


### PR DESCRIPTION
Added a `clang-format+-context` variable, replacing `clang-format+-apply-to-modifications-only` and `clang-format+-apply-to-modified-definition`. Possible values:

- **`'buffer`**: Reformat the whole buffer. This corresponds to `clang-format+-apply-to-modifications-only` set to `nil`.
- **`'definition`**: Reformat the enclosing definition (class/function/etc., but not namespace). This corresponds to `clang-format+-apply-to-modifications-only` set to `t` and `clang-format+-apply-to-modified-definition` set to `t`.
- **`'modification`**: Reformat only the modified parts. This corresponds to `clang-format+-apply-to-modifications-only` set to `t` and `clang-format+-apply-to-modified-definition` set to `nil`.

I think that this makes customization easier to understand.

What do you think? This is a just a suggestion; feel free to not apply it - no hard feelings. :slightly_smiling_face: